### PR TITLE
Accept a per-call timeout option on every request method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Every method that makes a request accepts a per-call `timeout` option that overrides the constructor `timeout` for that call. It also applies to the access token request the call may need to make.
+
 ## [0.5.0] - 2026-07-29
 
 ### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.6.0] - 2026-07-30
 
 ### Added
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,8 @@ method assigned to `this`. It is not an ES class; there is no `class` keyword in
 - `memory-cache` - In-memory caching for access tokens
 
 HTTP requests use the built-in `fetch`, so Node.js 18 or later is required and there is no HTTP
-dependency. Every request carries `signal: AbortSignal.timeout(options.timeout)`, default 10000ms.
+dependency. Every request carries `signal: AbortSignal.timeout(_options.timeout || options.timeout)`,
+so a per-call `timeout` option wins over the constructor value, which defaults to 10000ms.
 
 ### Testing
 - `node:test` with `node:assert`
@@ -77,7 +78,7 @@ The SDK requires:
 - `client_id` - DHL API client ID
 - `client_secret` - DHL API client secret
 - `environment_url` - API endpoint (defaults to sandbox: https://api-sandbox.dhlecs.com)
-- `timeout` - Milliseconds before a request is aborted (defaults to 10000)
+- `timeout` - Milliseconds before a request is aborted (defaults to 10000, overridable per call)
 
 Production URL: https://api.dhlecs.com
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ const dhlEcommerceSolutions = new DhlEcommerceSolutions({
 | `environment_url` | `https://api-sandbox.dhlecs.com` | API endpoint. Production is `https://api.dhlecs.com`. |
 | `timeout` | `10000` | Milliseconds to wait before aborting a request. |
 
+Every method that makes a request also accepts a `timeout` option, which overrides the constructor value for that call only. It covers the access token request the call may need to make.
+
+```javascript
+const response = await dhlEcommerceSolutions.findProducts(request, { timeout: 5000 });
+```
+
 ### Callbacks and async/await
 
 Every method that makes a request takes an optional callback. Omit it and the method returns a promise instead.
@@ -155,7 +161,7 @@ dhlEcommerceSolutions.createLabel(request, { format: 'PNG' }, function(err, resp
 });
 ```
 
-### dhlEcommerceSolutions.createManifest(request, [callback])
+### dhlEcommerceSolutions.createManifest(request, [options], [callback])
 
 Use the Manifest API to submit a request for closing out / manifesting packages and generate a Driver's Summary Manifest (DSM).
 
@@ -181,7 +187,7 @@ dhlEcommerceSolutions.createManifest(request, function(err, response) {
 });
 ```
 
-### dhlEcommerceSolutions.downloadManifest(pickup, requestId, [callback])
+### dhlEcommerceSolutions.downloadManifest(pickup, requestId, [options], [callback])
 
 For Manifest requests that were created using the Create Manifest API, the Download Manifest API is used to retrieve and download the manifests.
 
@@ -195,7 +201,7 @@ dhlEcommerceSolutions.downloadManifest('5351244', 'b56fe9d0-9bce-4d62-a11f-f8f86
 });
 ```
 
-### dhlEcommerceSolutions.findProducts(request, [callback])
+### dhlEcommerceSolutions.findProducts(request, [options], [callback])
 
 DHL eCommerce Americas Product Finder API enables clients to determine which DHL shipping products are suitable for a given shipping request including associated rates and estimated delivery dates (EDD).
 
@@ -243,7 +249,7 @@ dhlEcommerceSolutions.findProducts(request, function(err, response) {
 });
 ```
 
-### dhlEcommerceSolutions.getAccessToken([callback])
+### dhlEcommerceSolutions.getAccessToken([options], [callback])
 
 To access any of DHL eCommerce's API resources, client credentials (clientId and clientSecret) are required which must be exchanged for an access token.
 
@@ -257,7 +263,7 @@ dhlEcommerceSolutions.getAccessToken(function(err, accessToken) {
 });
 ```
 
-### dhlEcommerceSolutions.getTrackingByPackageId(packageId, [callback])
+### dhlEcommerceSolutions.getTrackingByPackageId(packageId, [options], [callback])
 
 This API is used to check the latest tracking status of any domestic or international package.
 
@@ -271,7 +277,7 @@ dhlEcommerceSolutions.getTrackingByPackageId('V4-TEST-1586965592482', function(e
 });
 ```
 
-### dhlEcommerceSolutions.getTrackingByTrackingId(trackingId, [callback])
+### dhlEcommerceSolutions.getTrackingByTrackingId(trackingId, [options], [callback])
 
 This API is used to check the latest tracking status of any domestic or international package using its tracking id.
 

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ function DhlEcommerceSolutions(args) {
         }
 
         const executor = async () => {
-            const accessToken = await this.getAccessToken();
+            const accessToken = await this.getAccessToken(_options);
 
             const res = await fetch(`${options.environment_url}/shipping/v4/label?format=${_options.format}`, {
                 body: JSON.stringify(_request),
@@ -106,7 +106,7 @@ function DhlEcommerceSolutions(args) {
                     'Content-Type': 'application/json'
                 },
                 method: 'POST',
-                signal: AbortSignal.timeout(options.timeout)
+                signal: AbortSignal.timeout(_options.timeout || options.timeout)
             });
 
             return await parseResponse(res);
@@ -123,9 +123,15 @@ function DhlEcommerceSolutions(args) {
      * Manifest specific open packages (recommended): Only packages specified in the request are added to a request id and only those items will be manifested.
      * Manifest all open items: The last 20,000 labels generated for the given pickup location are added to a request id and will be manifested.
      */
-    this.createManifest = function(_request, callback) {
+    this.createManifest = function(_request, _options = {}, callback) {
+        // Options are optional
+        if (typeof _options === 'function') {
+            callback = _options;
+            _options = {};
+        }
+
         const executor = async () => {
-            const accessToken = await this.getAccessToken();
+            const accessToken = await this.getAccessToken(_options);
 
             const res = await fetch(`${options.environment_url}/shipping/v4/manifest`, {
                 body: JSON.stringify(_request),
@@ -134,7 +140,7 @@ function DhlEcommerceSolutions(args) {
                     'Content-Type': 'application/json'
                 },
                 method: 'POST',
-                signal: AbortSignal.timeout(options.timeout)
+                signal: AbortSignal.timeout(_options.timeout || options.timeout)
             });
 
             return await parseResponse(res);
@@ -152,15 +158,21 @@ function DhlEcommerceSolutions(args) {
      * @param {string} pickup DHL eCommerce pickup account number. You will receive this after doing the onboarding with DHL sales
      * @param {string} requestId DHL eCommerce manifest request ID that was provided in the POST manifest response object
      */
-    this.downloadManifest = function(pickup, requestId, callback) {
+    this.downloadManifest = function(pickup, requestId, _options = {}, callback) {
+        // Options are optional
+        if (typeof _options === 'function') {
+            callback = _options;
+            _options = {};
+        }
+
         const executor = async () => {
-            const accessToken = await this.getAccessToken();
+            const accessToken = await this.getAccessToken(_options);
 
             const res = await fetch(`${options.environment_url}/shipping/v4/manifest/${pickup}/${requestId}`, {
                 headers: {
                     'Authorization': `Bearer ${accessToken.access_token}`
                 },
-                signal: AbortSignal.timeout(options.timeout)
+                signal: AbortSignal.timeout(_options.timeout || options.timeout)
             });
 
             return await parseResponse(res);
@@ -176,9 +188,15 @@ function DhlEcommerceSolutions(args) {
     /**
      * DHL eCommerce Americas Product Finder API enables clients to determine which DHL shipping products are suitable for a given shipping request including associated rates and estimated delivery dates.
      */
-    this.findProducts = function(_request, callback) {
+    this.findProducts = function(_request, _options = {}, callback) {
+        // Options are optional
+        if (typeof _options === 'function') {
+            callback = _options;
+            _options = {};
+        }
+
         const executor = async () => {
-            const accessToken = await this.getAccessToken();
+            const accessToken = await this.getAccessToken(_options);
 
             const res = await fetch(`${options.environment_url}/shipping/v4/products`, {
                 body: JSON.stringify(_request),
@@ -187,7 +205,7 @@ function DhlEcommerceSolutions(args) {
                     'Content-Type': 'application/json'
                 },
                 method: 'POST',
-                signal: AbortSignal.timeout(options.timeout)
+                signal: AbortSignal.timeout(_options.timeout || options.timeout)
             });
 
             return await parseResponse(res);
@@ -203,7 +221,13 @@ function DhlEcommerceSolutions(args) {
     /**
      * To access any of DHL eCommerce's API resources, client credentials (clientId and clientSecret) are required which must be exchanged for an access token.
      */
-    this.getAccessToken = function(callback) {
+    this.getAccessToken = function(_options = {}, callback) {
+        // Options are optional
+        if (typeof _options === 'function') {
+            callback = _options;
+            _options = {};
+        }
+
         const url = `${options.environment_url}/auth/v4/accesstoken`;
         const key = `${url}?client_id=${options.client_id}`;
 
@@ -225,7 +249,7 @@ function DhlEcommerceSolutions(args) {
                     'Content-Type': 'application/x-www-form-urlencoded'
                 },
                 method: 'POST',
-                signal: AbortSignal.timeout(options.timeout)
+                signal: AbortSignal.timeout(_options.timeout || options.timeout)
             });
 
             const response = await parseResponse(res);
@@ -246,15 +270,21 @@ function DhlEcommerceSolutions(args) {
     /**
      * Track using a single packageId.
      */
-    this.getTrackingByPackageId = function(packageId, callback) {
+    this.getTrackingByPackageId = function(packageId, _options = {}, callback) {
+        // Options are optional
+        if (typeof _options === 'function') {
+            callback = _options;
+            _options = {};
+        }
+
         const executor = async () => {
-            const accessToken = await this.getAccessToken();
+            const accessToken = await this.getAccessToken(_options);
 
             const res = await fetch(`${options.environment_url}/tracking/v4/package?packageId=${packageId}`, {
                 headers: {
                     'Authorization': `Bearer ${accessToken.access_token}`
                 },
-                signal: AbortSignal.timeout(options.timeout)
+                signal: AbortSignal.timeout(_options.timeout || options.timeout)
             });
 
             return await parseResponse(res);
@@ -270,15 +300,21 @@ function DhlEcommerceSolutions(args) {
     /**
      * Track using a single trackingId.
      */
-    this.getTrackingByTrackingId = function(trackingId, callback) {
+    this.getTrackingByTrackingId = function(trackingId, _options = {}, callback) {
+        // Options are optional
+        if (typeof _options === 'function') {
+            callback = _options;
+            _options = {};
+        }
+
         const executor = async () => {
-            const accessToken = await this.getAccessToken();
+            const accessToken = await this.getAccessToken(_options);
 
             const res = await fetch(`${options.environment_url}/tracking/v4/package?trackingId=${trackingId}`, {
                 headers: {
                     'Authorization': `Bearer ${accessToken.access_token}`
                 },
-                signal: AbortSignal.timeout(options.timeout)
+                signal: AbortSignal.timeout(_options.timeout || options.timeout)
             });
 
             return await parseResponse(res);

--- a/package.json
+++ b/package.json
@@ -29,5 +29,5 @@
         "test": "node --test --test-force-exit test",
         "test:only": "node --test --test-force-exit --test-only test"
     },
-    "version": "0.5.0"
+    "version": "0.6.0"
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1033,7 +1033,7 @@ test('DhlEcommerceSolutions', { concurrency: true, timeout: 10000 }, (t) => {
             });
         });
 
-        t.test('should return an error for non 200 status code', { timeout: 3000 }, () => {
+        t.test('should return an error for non 200 status code', { timeout: 8000 }, () => {
             return new Promise((resolve, reject) => {
                 let dhlEcommerceSolutions = new DhlEcommerceSolutions({
                     client_id: process.env.CLIENT_ID,

--- a/test/index.js
+++ b/test/index.js
@@ -637,6 +637,15 @@ test('DhlEcommerceSolutions', { concurrency: true, timeout: 10000 }, (t) => {
             assert(response.labels.every(label => label.labelData));
             assert(response.labels.every(label => label.format === 'ZPL'));
         });
+
+        t.test('should use the timeout specified in options', { timeout: 1000 }, async () => {
+            const client_id = crypto.randomUUID();
+            const dhlEcommerceSolutions = new DhlEcommerceSolutions({ client_id });
+
+            cache.put(`https://api-sandbox.dhlecs.com/auth/v4/accesstoken?client_id=${client_id}`, { access_token: 'test' }, 1000);
+
+            await assert.rejects(dhlEcommerceSolutions.createLabel({}, { timeout: 1 }), { name: 'TimeoutError' });
+        });
     });
 
     t.test('createManifest', { concurrency: true, timeout: 4000 }, (t) => {
@@ -777,6 +786,15 @@ test('DhlEcommerceSolutions', { concurrency: true, timeout: 10000 }, (t) => {
             assert.notStrictEqual(NaN, Date.parse(response.timestamp));
             assert.ok(response.requestId);
             assert.ok(response.link);
+        });
+
+        t.test('should use the timeout specified in options', { timeout: 1000 }, async () => {
+            const client_id = crypto.randomUUID();
+            const dhlEcommerceSolutions = new DhlEcommerceSolutions({ client_id });
+
+            cache.put(`https://api-sandbox.dhlecs.com/auth/v4/accesstoken?client_id=${client_id}`, { access_token: 'test' }, 1000);
+
+            await assert.rejects(dhlEcommerceSolutions.createManifest({}, { timeout: 1 }), { name: 'TimeoutError' });
         });
     });
 
@@ -946,6 +964,15 @@ test('DhlEcommerceSolutions', { concurrency: true, timeout: 10000 }, (t) => {
             assert.strictEqual(requestId, response.requestId);
             assert.strictEqual(['CREATED', 'IN_PROGRESS', 'COMPLETED'].includes(response.status), true);
             assert.notStrictEqual(NaN, Date.parse(response.timestamp));
+        });
+
+        t.test('should use the timeout specified in options', { timeout: 1000 }, async () => {
+            const client_id = crypto.randomUUID();
+            const dhlEcommerceSolutions = new DhlEcommerceSolutions({ client_id });
+
+            cache.put(`https://api-sandbox.dhlecs.com/auth/v4/accesstoken?client_id=${client_id}`, { access_token: 'test' }, 1000);
+
+            await assert.rejects(dhlEcommerceSolutions.downloadManifest('5351244', 'b56fe9d0-1111-2222-a11f-f8f8635f985a', { timeout: 1 }), { name: 'TimeoutError' });
         });
     });
 
@@ -1166,6 +1193,15 @@ test('DhlEcommerceSolutions', { concurrency: true, timeout: 10000 }, (t) => {
 
             assert(Array.isArray(response.products));
         });
+
+        t.test('should use the timeout specified in options', { timeout: 1000 }, async () => {
+            const client_id = crypto.randomUUID();
+            const dhlEcommerceSolutions = new DhlEcommerceSolutions({ client_id });
+
+            cache.put(`https://api-sandbox.dhlecs.com/auth/v4/accesstoken?client_id=${client_id}`, { access_token: 'test' }, 1000);
+
+            await assert.rejects(dhlEcommerceSolutions.findProducts({}, { timeout: 1 }), { name: 'TimeoutError' });
+        });
     });
 
     t.test('getAccessToken', { concurrency: true, timeout: 3000 }, (t) => {
@@ -1285,6 +1321,12 @@ test('DhlEcommerceSolutions', { concurrency: true, timeout: 10000 }, (t) => {
             assert(accessToken.client_id);
             assert(accessToken.expires_in);
             assert.strictEqual(accessToken.token_type, 'Bearer');
+        });
+
+        t.test('should use the timeout specified in options', { timeout: 1000 }, async () => {
+            const dhlEcommerceSolutions = new DhlEcommerceSolutions({ client_id: crypto.randomUUID() });
+
+            await assert.rejects(dhlEcommerceSolutions.getAccessToken({ timeout: 1 }), { name: 'TimeoutError' });
         });
     });
 
@@ -1420,6 +1462,15 @@ test('DhlEcommerceSolutions', { concurrency: true, timeout: 10000 }, (t) => {
 
             assert.strictEqual(response.packages[0].package.packageId, 'V4-TEST-1586965592482');
         });
+
+        t.test('should use the timeout specified in options', { timeout: 1000 }, async () => {
+            const client_id = crypto.randomUUID();
+            const dhlEcommerceSolutions = new DhlEcommerceSolutions({ client_id });
+
+            cache.put(`https://api-sandbox.dhlecs.com/auth/v4/accesstoken?client_id=${client_id}`, { access_token: 'test' }, 1000);
+
+            await assert.rejects(dhlEcommerceSolutions.getTrackingByPackageId('V4-TEST-1586965592482', { timeout: 1 }), { name: 'TimeoutError' });
+        });
     });
 
     t.test('getTrackingByTrackingId', { concurrency: true, timeout: 10000 }, (t) => {
@@ -1553,6 +1604,15 @@ test('DhlEcommerceSolutions', { concurrency: true, timeout: 10000 }, (t) => {
             const response = await dhlEcommerceSolutions.getTrackingByTrackingId('9374869903500011991299');
 
             assert.strictEqual(response.packages.length, 0);
+        });
+
+        t.test('should use the timeout specified in options', { timeout: 1000 }, async () => {
+            const client_id = crypto.randomUUID();
+            const dhlEcommerceSolutions = new DhlEcommerceSolutions({ client_id });
+
+            cache.put(`https://api-sandbox.dhlecs.com/auth/v4/accesstoken?client_id=${client_id}`, { access_token: 'test' }, 1000);
+
+            await assert.rejects(dhlEcommerceSolutions.getTrackingByTrackingId('9374869903500011991299', { timeout: 1 }), { name: 'TimeoutError' });
         });
     });
 });


### PR DESCRIPTION
## Why

The constructor `timeout` is the only lever in 0.5.0, so one value has to cover calls with very different deadlines. In fulfillment-service that means the Salesforce-facing rate call — 5-minute cadence, caller has a deadline — and the hourly manifest cron share a ceiling, and can't both have the number they want.

The house executor pattern already calls for a per-call `options = {}` on every method with `AbortSignal.timeout(options.timeout || 10000)`. #11 only did that for `createLabel`, so this finishes the pattern rather than adding to it.

## What

- `createManifest`, `downloadManifest`, `findProducts`, `getAccessToken`, `getTrackingByPackageId`, and `getTrackingByTrackingId` take the pattern's `options` argument, with the same `typeof _options === 'function'` guard `createLabel` already had.
- Every request resolves its timeout as `_options.timeout || options.timeout`, so the constructor value stays the default.
- The per-call value is threaded into the internal `getAccessToken` call, so a 5s budget bounds the whole call instead of just the second leg. The token is cached, so that request usually doesn't fire.

Additive — every existing callback and `await` call keeps working unchanged, including `downloadManifest(pickup, requestId, callback)` and `getAccessToken(callback)`.

## Tests

Seven new tests, one per method: pre-seed the token cache under a random `client_id`, call with `{ timeout: 1 }`, assert the call rejects with `TimeoutError`. With the constructor default at 10000ms the call would otherwise succeed, so the assertion is what proves the per-call value took effect. They add no dependency on sandbox latency — the abort fires at 1ms.

Locally (no DHL credentials, so every live-sandbox test fails with `Unauthorized` on both branches):

| | tests | pass | fail |
| --- | --- | --- | --- |
| `9650de4` (main) | 74 | 36 | 38 |
| this branch | 81 | 43 | 38 |

Same 38 credential-dependent failures, 7 added and passing. CI has the secrets, so treat its run as the real result — including coverage, which Coveralls fails on any decrease.

## Docs

README gets the six updated signatures and a note under the options table; CHANGELOG gets an `[Unreleased]` entry; CLAUDE.md's timeout line is corrected to match. No `version` bump.
