### PR TITLE
Drop callback support and release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2026-07-30
+
+### Breaking
+
+- Callbacks are gone. Every method that makes a request returns a promise and no longer accepts a callback argument. Replace `method(args, function(err, response) { ... })` with `await method(args)`, and handle failures with `try`/`catch` instead of an `err` argument.
+- Because the callback argument is gone, an options object is no longer distinguished from a callback at runtime. `getAccessToken(options)`, `createManifest(request, options)`, `downloadManifest(pickup, requestId, options)`, `findProducts(request, options)`, `getTrackingByPackageId(packageId, options)`, and `getTrackingByTrackingId(trackingId, options)` take their options in the same position as before.
+
 ## [0.6.0] - 2026-07-30
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,9 +36,8 @@ method assigned to `this`. It is not an ES class; there is no `class` keyword in
    - Access tokens are cached in memory using `memory-cache` module
    - Tokens auto-refresh at half their expiry time
 
-2. **API Methods** - Every method that makes a request takes an optional callback and returns a
-   promise when the callback is omitted (the executor pattern). `applyDimensionalWeight` is
-   synchronous.
+2. **API Methods** - Every method that makes a request is an `async function` and returns a
+   promise. Callbacks were removed in 1.0.0. `applyDimensionalWeight` is synchronous.
 
    - `getAccessToken()` - Handles OAuth authentication
    - `createLabel()` - Generate shipping labels (ZPL or PNG format)

--- a/README.md
+++ b/README.md
@@ -38,23 +38,17 @@ Every method that makes a request also accepts a `timeout` option, which overrid
 const response = await dhlEcommerceSolutions.findProducts(request, { timeout: 5000 });
 ```
 
-### Callbacks and async/await
+### async/await
 
-Every method that makes a request takes an optional callback. Omit it and the method returns a promise instead.
+Every method that makes a request returns a promise. `applyDimensionalWeight` is synchronous.
 
 ```javascript
-// Callback
-dhlEcommerceSolutions.getTrackingByPackageId('V4-TEST-1586965592482', function(err, response) {
-    console.log(response);
-});
-
-// async/await
 const response = await dhlEcommerceSolutions.getTrackingByPackageId('V4-TEST-1586965592482');
 ```
 
 ### Errors
 
-A response other than 200 produces an [HttpError](https://www.npmjs.com/package/@stores.com/http-error), passed to the callback or thrown from the promise.
+A response other than 200 produces an [HttpError](https://www.npmjs.com/package/@stores.com/http-error), thrown from the promise.
 
 ```javascript
 try {
@@ -116,7 +110,7 @@ const request = {
 dhlEcommerceSolutions.applyDimensionalWeight(request);
 ```
 
-### dhlEcommerceSolutions.createLabel(request, [options], [callback])
+### dhlEcommerceSolutions.createLabel(request, [options])
 
 The Label endpoint can generate a US Domestic or an International label.
 
@@ -156,12 +150,12 @@ const request = {
     }
 };
 
-dhlEcommerceSolutions.createLabel(request, { format: 'PNG' }, function(err, response) {
-    console.log(response);
-});
+const response = await dhlEcommerceSolutions.createLabel(request, { format: 'PNG' });
+
+console.log(response);
 ```
 
-### dhlEcommerceSolutions.createManifest(request, [options], [callback])
+### dhlEcommerceSolutions.createManifest(request, [options])
 
 Use the Manifest API to submit a request for closing out / manifesting packages and generate a Driver's Summary Manifest (DSM).
 
@@ -182,12 +176,12 @@ const request = {
     pickup: '5351244'
 };
 
-dhlEcommerceSolutions.createManifest(request, function(err, response) {
-    console.log(response);
-});
+const response = await dhlEcommerceSolutions.createManifest(request);
+
+console.log(response);
 ```
 
-### dhlEcommerceSolutions.downloadManifest(pickup, requestId, [options], [callback])
+### dhlEcommerceSolutions.downloadManifest(pickup, requestId, [options])
 
 For Manifest requests that were created using the Create Manifest API, the Download Manifest API is used to retrieve and download the manifests.
 
@@ -196,12 +190,12 @@ https://docs.api.dhlecs.com/?version=latest#ed99b453-b760-4a54-9fb9-7fa1fcac63ee
 **Example**
 
 ```javascript
-dhlEcommerceSolutions.downloadManifest('5351244', 'b56fe9d0-9bce-4d62-a11f-f8f8635f985a', function(err, response) {
-    console.log(response);
-});
+const response = await dhlEcommerceSolutions.downloadManifest('5351244', 'b56fe9d0-9bce-4d62-a11f-f8f8635f985a');
+
+console.log(response);
 ```
 
-### dhlEcommerceSolutions.findProducts(request, [options], [callback])
+### dhlEcommerceSolutions.findProducts(request, [options])
 
 DHL eCommerce Americas Product Finder API enables clients to determine which DHL shipping products are suitable for a given shipping request including associated rates and estimated delivery dates (EDD).
 
@@ -244,12 +238,12 @@ const request = {
     }
 };
 
-dhlEcommerceSolutions.findProducts(request, function(err, response) {
-    console.log(response);
-});
+const response = await dhlEcommerceSolutions.findProducts(request);
+
+console.log(response);
 ```
 
-### dhlEcommerceSolutions.getAccessToken([options], [callback])
+### dhlEcommerceSolutions.getAccessToken([options])
 
 To access any of DHL eCommerce's API resources, client credentials (clientId and clientSecret) are required which must be exchanged for an access token.
 
@@ -258,12 +252,12 @@ https://docs.api.dhlecs.com/#9dc55deb-9f2b-4ee5-af36-40d102beafaa
 **Example**
 
 ```javascript
-dhlEcommerceSolutions.getAccessToken(function(err, accessToken) {
-    console.log(accessToken);
-});
+const accessToken = await dhlEcommerceSolutions.getAccessToken();
+
+console.log(accessToken);
 ```
 
-### dhlEcommerceSolutions.getTrackingByPackageId(packageId, [options], [callback])
+### dhlEcommerceSolutions.getTrackingByPackageId(packageId, [options])
 
 This API is used to check the latest tracking status of any domestic or international package.
 
@@ -272,12 +266,12 @@ https://docs.api.dhlecs.com/?version=latest#bc8f6e5c-1bb2-45b9-8731-2a7feb5c71c7
 **Example**
 
 ```javascript
-dhlEcommerceSolutions.getTrackingByPackageId('V4-TEST-1586965592482', function(err, response) {
-    console.log(response);
-});
+const response = await dhlEcommerceSolutions.getTrackingByPackageId('V4-TEST-1586965592482');
+
+console.log(response);
 ```
 
-### dhlEcommerceSolutions.getTrackingByTrackingId(trackingId, [options], [callback])
+### dhlEcommerceSolutions.getTrackingByTrackingId(trackingId, [options])
 
 This API is used to check the latest tracking status of any domestic or international package using its tracking id.
 
@@ -286,7 +280,7 @@ https://docs.api.dhlecs.com/?version=latest#bc8f6e5c-1bb2-45b9-8731-2a7feb5c71c7
 **Example**
 
 ```javascript
-dhlEcommerceSolutions.getTrackingByTrackingId('420300249361211015300010272828', function(err, response) {
-    console.log(response);
-});
+const response = await dhlEcommerceSolutions.getTrackingByTrackingId('420300249361211015300010272828');
+
+console.log(response);
 ```

--- a/index.js
+++ b/index.js
@@ -84,73 +84,45 @@ function DhlEcommerceSolutions(args) {
     /**
      * The Label endpoint can generate a US Domestic or an International label.
      */
-    this.createLabel = function(_request, _options = {}, callback) {
-        // Options are optional
-        if (typeof _options === 'function') {
-            callback = _options;
-            _options = {};
-        }
-
+    this.createLabel = async function(_request, _options = {}) {
         // Default format is ZPL
         if (!_options.format) {
             _options.format = 'ZPL';
         }
 
-        const executor = async () => {
-            const accessToken = await this.getAccessToken(_options);
+        const accessToken = await this.getAccessToken(_options);
 
-            const res = await fetch(`${options.environment_url}/shipping/v4/label?format=${_options.format}`, {
-                body: JSON.stringify(_request),
-                headers: {
-                    'Authorization': `Bearer ${accessToken.access_token}`,
-                    'Content-Type': 'application/json'
-                },
-                method: 'POST',
-                signal: AbortSignal.timeout(_options.timeout || options.timeout)
-            });
+        const res = await fetch(`${options.environment_url}/shipping/v4/label?format=${_options.format}`, {
+            body: JSON.stringify(_request),
+            headers: {
+                'Authorization': `Bearer ${accessToken.access_token}`,
+                'Content-Type': 'application/json'
+            },
+            method: 'POST',
+            signal: AbortSignal.timeout(_options.timeout || options.timeout)
+        });
 
-            return await parseResponse(res);
-        };
-
-        if (callback) {
-            executor().then(result => callback(null, result)).catch(callback);
-        } else {
-            return executor();
-        }
+        return await parseResponse(res);
     };
 
     /**
      * Manifest specific open packages (recommended): Only packages specified in the request are added to a request id and only those items will be manifested.
      * Manifest all open items: The last 20,000 labels generated for the given pickup location are added to a request id and will be manifested.
      */
-    this.createManifest = function(_request, _options = {}, callback) {
-        // Options are optional
-        if (typeof _options === 'function') {
-            callback = _options;
-            _options = {};
-        }
+    this.createManifest = async function(_request, _options = {}) {
+        const accessToken = await this.getAccessToken(_options);
 
-        const executor = async () => {
-            const accessToken = await this.getAccessToken(_options);
+        const res = await fetch(`${options.environment_url}/shipping/v4/manifest`, {
+            body: JSON.stringify(_request),
+            headers: {
+                'Authorization': `Bearer ${accessToken.access_token}`,
+                'Content-Type': 'application/json'
+            },
+            method: 'POST',
+            signal: AbortSignal.timeout(_options.timeout || options.timeout)
+        });
 
-            const res = await fetch(`${options.environment_url}/shipping/v4/manifest`, {
-                body: JSON.stringify(_request),
-                headers: {
-                    'Authorization': `Bearer ${accessToken.access_token}`,
-                    'Content-Type': 'application/json'
-                },
-                method: 'POST',
-                signal: AbortSignal.timeout(_options.timeout || options.timeout)
-            });
-
-            return await parseResponse(res);
-        };
-
-        if (callback) {
-            executor().then(result => callback(null, result)).catch(callback);
-        } else {
-            return executor();
-        }
+        return await parseResponse(res);
     };
 
     /**
@@ -158,173 +130,103 @@ function DhlEcommerceSolutions(args) {
      * @param {string} pickup DHL eCommerce pickup account number. You will receive this after doing the onboarding with DHL sales
      * @param {string} requestId DHL eCommerce manifest request ID that was provided in the POST manifest response object
      */
-    this.downloadManifest = function(pickup, requestId, _options = {}, callback) {
-        // Options are optional
-        if (typeof _options === 'function') {
-            callback = _options;
-            _options = {};
-        }
+    this.downloadManifest = async function(pickup, requestId, _options = {}) {
+        const accessToken = await this.getAccessToken(_options);
 
-        const executor = async () => {
-            const accessToken = await this.getAccessToken(_options);
+        const res = await fetch(`${options.environment_url}/shipping/v4/manifest/${pickup}/${requestId}`, {
+            headers: {
+                'Authorization': `Bearer ${accessToken.access_token}`
+            },
+            signal: AbortSignal.timeout(_options.timeout || options.timeout)
+        });
 
-            const res = await fetch(`${options.environment_url}/shipping/v4/manifest/${pickup}/${requestId}`, {
-                headers: {
-                    'Authorization': `Bearer ${accessToken.access_token}`
-                },
-                signal: AbortSignal.timeout(_options.timeout || options.timeout)
-            });
-
-            return await parseResponse(res);
-        };
-
-        if (callback) {
-            executor().then(result => callback(null, result)).catch(callback);
-        } else {
-            return executor();
-        }
+        return await parseResponse(res);
     };
 
     /**
      * DHL eCommerce Americas Product Finder API enables clients to determine which DHL shipping products are suitable for a given shipping request including associated rates and estimated delivery dates.
      */
-    this.findProducts = function(_request, _options = {}, callback) {
-        // Options are optional
-        if (typeof _options === 'function') {
-            callback = _options;
-            _options = {};
-        }
+    this.findProducts = async function(_request, _options = {}) {
+        const accessToken = await this.getAccessToken(_options);
 
-        const executor = async () => {
-            const accessToken = await this.getAccessToken(_options);
+        const res = await fetch(`${options.environment_url}/shipping/v4/products`, {
+            body: JSON.stringify(_request),
+            headers: {
+                'Authorization': `Bearer ${accessToken.access_token}`,
+                'Content-Type': 'application/json'
+            },
+            method: 'POST',
+            signal: AbortSignal.timeout(_options.timeout || options.timeout)
+        });
 
-            const res = await fetch(`${options.environment_url}/shipping/v4/products`, {
-                body: JSON.stringify(_request),
-                headers: {
-                    'Authorization': `Bearer ${accessToken.access_token}`,
-                    'Content-Type': 'application/json'
-                },
-                method: 'POST',
-                signal: AbortSignal.timeout(_options.timeout || options.timeout)
-            });
-
-            return await parseResponse(res);
-        };
-
-        if (callback) {
-            executor().then(result => callback(null, result)).catch(callback);
-        } else {
-            return executor();
-        }
+        return await parseResponse(res);
     };
 
     /**
      * To access any of DHL eCommerce's API resources, client credentials (clientId and clientSecret) are required which must be exchanged for an access token.
      */
-    this.getAccessToken = function(_options = {}, callback) {
-        // Options are optional
-        if (typeof _options === 'function') {
-            callback = _options;
-            _options = {};
-        }
-
+    this.getAccessToken = async function(_options = {}) {
         const url = `${options.environment_url}/auth/v4/accesstoken`;
         const key = `${url}?client_id=${options.client_id}`;
 
-        const executor = async () => {
-            // Try to get the access token from memory cache
-            const accessToken = cache.get(key);
+        // Try to get the access token from memory cache
+        const accessToken = cache.get(key);
 
-            if (accessToken) {
-                return accessToken;
-            }
-
-            const res = await fetch(url, {
-                body: new URLSearchParams({
-                    client_id: options.client_id,
-                    client_secret: options.client_secret,
-                    grant_type: 'client_credentials'
-                }),
-                headers: {
-                    'Content-Type': 'application/x-www-form-urlencoded'
-                },
-                method: 'POST',
-                signal: AbortSignal.timeout(_options.timeout || options.timeout)
-            });
-
-            const response = await parseResponse(res);
-
-            // Put the access token in memory cache
-            cache.put(key, response, response.expires_in * 1000 / 2);
-
-            return response;
-        };
-
-        if (callback) {
-            executor().then(result => callback(null, result)).catch(callback);
-        } else {
-            return executor();
+        if (accessToken) {
+            return accessToken;
         }
+
+        const res = await fetch(url, {
+            body: new URLSearchParams({
+                client_id: options.client_id,
+                client_secret: options.client_secret,
+                grant_type: 'client_credentials'
+            }),
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded'
+            },
+            method: 'POST',
+            signal: AbortSignal.timeout(_options.timeout || options.timeout)
+        });
+
+        const response = await parseResponse(res);
+
+        // Put the access token in memory cache
+        cache.put(key, response, response.expires_in * 1000 / 2);
+
+        return response;
     };
 
     /**
      * Track using a single packageId.
      */
-    this.getTrackingByPackageId = function(packageId, _options = {}, callback) {
-        // Options are optional
-        if (typeof _options === 'function') {
-            callback = _options;
-            _options = {};
-        }
+    this.getTrackingByPackageId = async function(packageId, _options = {}) {
+        const accessToken = await this.getAccessToken(_options);
 
-        const executor = async () => {
-            const accessToken = await this.getAccessToken(_options);
+        const res = await fetch(`${options.environment_url}/tracking/v4/package?packageId=${packageId}`, {
+            headers: {
+                'Authorization': `Bearer ${accessToken.access_token}`
+            },
+            signal: AbortSignal.timeout(_options.timeout || options.timeout)
+        });
 
-            const res = await fetch(`${options.environment_url}/tracking/v4/package?packageId=${packageId}`, {
-                headers: {
-                    'Authorization': `Bearer ${accessToken.access_token}`
-                },
-                signal: AbortSignal.timeout(_options.timeout || options.timeout)
-            });
-
-            return await parseResponse(res);
-        };
-
-        if (callback) {
-            executor().then(result => callback(null, result)).catch(callback);
-        } else {
-            return executor();
-        }
+        return await parseResponse(res);
     };
 
     /**
      * Track using a single trackingId.
      */
-    this.getTrackingByTrackingId = function(trackingId, _options = {}, callback) {
-        // Options are optional
-        if (typeof _options === 'function') {
-            callback = _options;
-            _options = {};
-        }
+    this.getTrackingByTrackingId = async function(trackingId, _options = {}) {
+        const accessToken = await this.getAccessToken(_options);
 
-        const executor = async () => {
-            const accessToken = await this.getAccessToken(_options);
+        const res = await fetch(`${options.environment_url}/tracking/v4/package?trackingId=${trackingId}`, {
+            headers: {
+                'Authorization': `Bearer ${accessToken.access_token}`
+            },
+            signal: AbortSignal.timeout(_options.timeout || options.timeout)
+        });
 
-            const res = await fetch(`${options.environment_url}/tracking/v4/package?trackingId=${trackingId}`, {
-                headers: {
-                    'Authorization': `Bearer ${accessToken.access_token}`
-                },
-                signal: AbortSignal.timeout(_options.timeout || options.timeout)
-            });
-
-            return await parseResponse(res);
-        };
-
-        if (callback) {
-            executor().then(result => callback(null, result)).catch(callback);
-        } else {
-            return executor();
-        }
+        return await parseResponse(res);
     };
 }
 

--- a/package.json
+++ b/package.json
@@ -29,5 +29,5 @@
         "test": "node --test --test-force-exit test",
         "test:only": "node --test --test-force-exit --test-only test"
     },
-    "version": "0.6.0"
+    "version": "1.0.0"
 }

--- a/test/index.js
+++ b/test/index.js
@@ -371,230 +371,116 @@ test('DhlEcommerceSolutions', { concurrency: true, timeout: 10000 }, (t) => {
     });
 
     t.test('createLabel', { concurrency: true, timeout: 4000 }, (t) => {
-        t.test('should return an error for invalid environment_url', { timeout: 1000 }, () => {
-            return new Promise((resolve, reject) => {
-                const dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                    environment_url: 'invalid'
-                });
+        t.test('should return an error for invalid environment_url after getAccessToken', { timeout: 3000 }, async () => {
+            let dhlEcommerceSolutions = new DhlEcommerceSolutions({
+                client_id: process.env.CLIENT_ID,
+                client_secret: process.env.CLIENT_SECRET
+            });
 
-                dhlEcommerceSolutions.createLabel({}, (err, response) => {
-                    try {
-                        assert(err);
-                        assert.strictEqual(err.message, 'Failed to parse URL from invalid/auth/v4/accesstoken');
-                        assert.strictEqual(err.status, undefined);
-                        assert.strictEqual(response, undefined);
-                        resolve();
-                    } catch (e) {
-                        reject(e);
-                    }
-                });
+            const accessToken = await dhlEcommerceSolutions.getAccessToken();
+
+            dhlEcommerceSolutions = new DhlEcommerceSolutions({
+                environment_url: 'invalid'
+            });
+
+            // Update cache
+            cache.put('invalid/auth/v4/accesstoken?client_id=undefined', accessToken, accessToken.expires_in * 1000 / 2);
+
+            await assert.rejects(dhlEcommerceSolutions.createLabel({}), err => {
+                assert.strictEqual(err.message, 'Failed to parse URL from invalid/shipping/v4/label?format=ZPL');
+                assert.strictEqual(err.status, undefined);
+                return true;
             });
         });
 
-        t.test('should return an error for invalid environment_url after getAccessToken', { timeout: 3000 }, () => {
-            return new Promise((resolve, reject) => {
-                let dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                    client_id: process.env.CLIENT_ID,
-                    client_secret: process.env.CLIENT_SECRET
-                });
+        t.test('should return an error for non 200 status code', { timeout: 4000 }, async () => {
+            let dhlEcommerceSolutions = new DhlEcommerceSolutions({
+                client_id: process.env.CLIENT_ID,
+                client_secret: process.env.CLIENT_SECRET
+            });
 
-                dhlEcommerceSolutions.getAccessToken((err, accessToken) => {
-                    try {
-                        assert.ifError(err);
+            await dhlEcommerceSolutions.getAccessToken();
 
-                        dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                            environment_url: 'invalid'
-                        });
+            dhlEcommerceSolutions = new DhlEcommerceSolutions({
+                environment_url: 'https://httpbun.com/status/500#'
+            });
 
-                        // Update cache
-                        cache.put('invalid/auth/v4/accesstoken?client_id=undefined', accessToken, accessToken.expires_in * 1000 / 2);
-
-                        dhlEcommerceSolutions.createLabel({}, (err, response) => {
-                            try {
-                                assert(err);
-                                assert.strictEqual(err.message, 'Failed to parse URL from invalid/shipping/v4/label?format=ZPL');
-                                assert.strictEqual(err.status, undefined);
-                                assert.strictEqual(response, undefined);
-                                resolve();
-                            } catch (e) {
-                                reject(e);
-                            }
-                        });
-                    } catch (e) {
-                        reject(e);
-                    }
-                });
+            await assert.rejects(dhlEcommerceSolutions.createLabel({}), err => {
+                assert.strictEqual(err.message, '500 Internal Server Error');
+                assert.strictEqual(err.cause.status, 500);
+                return true;
             });
         });
 
-        t.test('should return an error for non 200 status code', { timeout: 4000 }, () => {
-            return new Promise((resolve, reject) => {
-                let dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                    client_id: process.env.CLIENT_ID,
-                    client_secret: process.env.CLIENT_SECRET
-                });
+        t.test('should return an error when no body is specified', { timeout: 3000 }, async () => {
+            const dhlEcommerceSolutions = new DhlEcommerceSolutions({
+                client_id: process.env.CLIENT_ID,
+                client_secret: process.env.CLIENT_SECRET
+            });
 
-                dhlEcommerceSolutions.getAccessToken((err) => {
-                    try {
-                        assert.ifError(err);
-
-                        dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                            environment_url: 'https://httpbun.com/status/500#'
-                        });
-
-                        dhlEcommerceSolutions.createLabel({}, (err, response) => {
-                            try {
-                                assert(err);
-                                assert.strictEqual(err.message, '500 Internal Server Error');
-                                assert.strictEqual(err.cause.status, 500);
-                                assert.strictEqual(response, undefined);
-                                resolve();
-                            } catch (e) {
-                                reject(e);
-                            }
-                        });
-                    } catch (e) {
-                        reject(e);
-                    }
-                });
+            await assert.rejects(dhlEcommerceSolutions.createLabel({}), err => {
+                assert.strictEqual(err.cause.status, 400);
+                return true;
             });
         });
 
-        t.test('should return an error when no body is specified', { timeout: 3000 }, () => {
-            return new Promise((resolve, reject) => {
-                const dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                    client_id: process.env.CLIENT_ID,
-                    client_secret: process.env.CLIENT_SECRET
-                });
-
-                dhlEcommerceSolutions.createLabel({}, (err, response) => {
-                    try {
-                        assert(err);
-                        assert.strictEqual(err.cause.status, 400);
-                        assert.strictEqual(response, undefined);
-                        resolve();
-                    } catch (e) {
-                        reject(e);
-                    }
-                });
+        t.test('should return a valid response for PNG format', { timeout: 3000 }, async () => {
+            const dhlEcommerceSolutions = new DhlEcommerceSolutions({
+                client_id: process.env.CLIENT_ID,
+                client_secret: process.env.CLIENT_SECRET
             });
+
+            const _request = {
+                consigneeAddress: {
+                    address1: '114 Whitney Ave',
+                    city: 'New Haven',
+                    country: 'US',
+                    name: 'John Doe',
+                    postalCode: '06510',
+                    state: 'CT'
+                },
+                distributionCenter: 'USDFW1',
+                orderedProductId: 'GND',
+                packageDetail: {
+                    packageDescription: 'ORDER NO 20483739DFDR',
+                    packageId: crypto.randomUUID().substring(0, 30),
+                    weight: {
+                        unitOfMeasure: 'LB',
+                        value: 3
+                    }
+                },
+                pickup: '5351244',
+                returnAddress: {
+                    address1: '1950 Parker Road',
+                    address2: 'Receiving Door 32',
+                    city: 'Carrollton',
+                    companyName: 'Mercatalyst',
+                    country: 'US',
+                    postalCode: '75010',
+                    state: 'TX'
+                }
+            };
+
+            const response = await dhlEcommerceSolutions.createLabel(_request, { format: 'PNG' });
+
+            assert(response);
+            assert(response.labels.every(label => label.labelData));
+            assert(response.labels.every(label => label.format === 'PNG'));
         });
 
-        t.test('should return a valid response', { timeout: 3000 }, () => {
-            return new Promise((resolve, reject) => {
-                const dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                    client_id: process.env.CLIENT_ID,
-                    client_secret: process.env.CLIENT_SECRET
-                });
-
-                const _request = {
-                    consigneeAddress: {
-                        address1: '114 Whitney Ave',
-                        city: 'New Haven',
-                        country: 'US',
-                        name: 'John Doe',
-                        postalCode: '06510',
-                        state: 'CT'
-                    },
-                    distributionCenter: 'USDFW1',
-                    orderedProductId: 'GND',
-                    packageDetail: {
-                        packageDescription: 'ORDER NO 20483739DFDR',
-                        packageId: crypto.randomUUID().substring(0, 30),
-                        weight: {
-                            unitOfMeasure: 'LB',
-                            value: 3
-                        }
-                    },
-                    pickup: '5351244',
-                    returnAddress: {
-                        address1: '1950 Parker Road',
-                        address2: 'Receiving Door 32',
-                        city: 'Carrollton',
-                        companyName: 'Mercatalyst',
-                        country: 'US',
-                        postalCode: '75010',
-                        state: 'TX'
-                    }
-                };
-
-                dhlEcommerceSolutions.createLabel(_request, (err, response) => {
-                    try {
-                        assert.ifError(err);
-                        assert(response);
-                        assert(response.labels.every(label => label.labelData));
-                        assert(response.labels.every(label => label.format === 'ZPL'));
-                        resolve();
-                    } catch (e) {
-                        reject(e);
-                    }
-                });
-            });
-        });
-
-        t.test('should return a valid response for PNG format', { timeout: 3000 }, () => {
-            return new Promise((resolve, reject) => {
-                const dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                    client_id: process.env.CLIENT_ID,
-                    client_secret: process.env.CLIENT_SECRET
-                });
-
-                const _request = {
-                    consigneeAddress: {
-                        address1: '114 Whitney Ave',
-                        city: 'New Haven',
-                        country: 'US',
-                        name: 'John Doe',
-                        postalCode: '06510',
-                        state: 'CT'
-                    },
-                    distributionCenter: 'USDFW1',
-                    orderedProductId: 'GND',
-                    packageDetail: {
-                        packageDescription: 'ORDER NO 20483739DFDR',
-                        packageId: crypto.randomUUID().substring(0, 30),
-                        weight: {
-                            unitOfMeasure: 'LB',
-                            value: 3
-                        }
-                    },
-                    pickup: '5351244',
-                    returnAddress: {
-                        address1: '1950 Parker Road',
-                        address2: 'Receiving Door 32',
-                        city: 'Carrollton',
-                        companyName: 'Mercatalyst',
-                        country: 'US',
-                        postalCode: '75010',
-                        state: 'TX'
-                    }
-                };
-
-                dhlEcommerceSolutions.createLabel(_request, { format: 'PNG' }, (err, response) => {
-                    try {
-                        assert.ifError(err);
-                        assert(response);
-                        assert(response.labels.every(label => label.labelData));
-                        assert(response.labels.every(label => label.format === 'PNG'));
-                        resolve();
-                    } catch (e) {
-                        reject(e);
-                    }
-                });
-            });
-        });
-
-        t.test('should reject for invalid environment_url when no callback is provided', { timeout: 1000 }, async () => {
+        t.test('should reject for invalid environment_url', { timeout: 1000 }, async () => {
             const dhlEcommerceSolutions = new DhlEcommerceSolutions({
                 environment_url: 'invalid'
             });
 
-            await assert.rejects(dhlEcommerceSolutions.createLabel({}), {
-                message: 'Failed to parse URL from invalid/auth/v4/accesstoken'
+            await assert.rejects(dhlEcommerceSolutions.createLabel({}), err => {
+                assert.strictEqual(err.message, 'Failed to parse URL from invalid/auth/v4/accesstoken');
+                assert.strictEqual(err.status, undefined);
+                return true;
             });
         });
 
-        t.test('should return a valid response when no callback is provided', { timeout: 3000 }, async () => {
+        t.test('should return a valid response', { timeout: 3000 }, async () => {
             const dhlEcommerceSolutions = new DhlEcommerceSolutions({
                 client_id: process.env.CLIENT_ID,
                 client_secret: process.env.CLIENT_SECRET
@@ -649,132 +535,63 @@ test('DhlEcommerceSolutions', { concurrency: true, timeout: 10000 }, (t) => {
     });
 
     t.test('createManifest', { concurrency: true, timeout: 4000 }, (t) => {
-        t.test('should return an error for invalid environment_url', { timeout: 1000 }, () => {
-            return new Promise((resolve, reject) => {
-                const dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                    environment_url: 'invalid'
-                });
+        t.test('should return an error for invalid environment_url after getAccessToken', { timeout: 3000 }, async () => {
+            let dhlEcommerceSolutions = new DhlEcommerceSolutions({
+                client_id: process.env.CLIENT_ID,
+                client_secret: process.env.CLIENT_SECRET
+            });
 
-                dhlEcommerceSolutions.createManifest({ manifests: [], pickup: '1234567' }, (err, response) => {
-                    try {
-                        assert(err);
-                        assert.strictEqual(err.message, 'Failed to parse URL from invalid/auth/v4/accesstoken');
-                        assert.strictEqual(err.status, undefined);
-                        assert.strictEqual(response, undefined);
-                        resolve();
-                    } catch (e) {
-                        reject(e);
-                    }
-                });
+            const accessToken = await dhlEcommerceSolutions.getAccessToken();
+
+            dhlEcommerceSolutions = new DhlEcommerceSolutions({
+                environment_url: 'invalid'
+            });
+
+            // Update cache
+            cache.put('invalid/auth/v4/accesstoken?client_id=undefined', accessToken, accessToken.expires_in * 1000 / 2);
+
+            await assert.rejects(dhlEcommerceSolutions.createManifest({ manifests: [], pickup: '5351244' }), err => {
+                assert.strictEqual(err.message, 'Failed to parse URL from invalid/shipping/v4/manifest');
+                assert.strictEqual(err.status, undefined);
+                return true;
             });
         });
 
-        t.test('should return an error for invalid environment_url after getAccessToken', { timeout: 3000 }, () => {
-            return new Promise((resolve, reject) => {
-                let dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                    client_id: process.env.CLIENT_ID,
-                    client_secret: process.env.CLIENT_SECRET
-                });
+        t.test('should return an error for non 200 status code', { timeout: 4000 }, async () => {
+            let dhlEcommerceSolutions = new DhlEcommerceSolutions({
+                client_id: process.env.CLIENT_ID,
+                client_secret: process.env.CLIENT_SECRET
+            });
 
-                dhlEcommerceSolutions.getAccessToken((err, accessToken) => {
-                    try {
-                        assert.ifError(err);
+            const accessToken = await dhlEcommerceSolutions.getAccessToken();
 
-                        dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                            environment_url: 'invalid'
-                        });
+            // Update cache
+            cache.put('https://httpbun.com/status/500#/auth/v4/accesstoken?client_id=undefined', accessToken, accessToken.expires_in * 1000 / 2);
 
-                        // Update cache
-                        cache.put('invalid/auth/v4/accesstoken?client_id=undefined', accessToken, accessToken.expires_in * 1000 / 2);
+            dhlEcommerceSolutions = new DhlEcommerceSolutions({
+                environment_url: 'https://httpbun.com/status/500#'
+            });
 
-                        dhlEcommerceSolutions.createManifest({ manifests: [], pickup: '5351244' }, (err, response) => {
-                            try {
-                                assert(err);
-                                assert.strictEqual(err.message, 'Failed to parse URL from invalid/shipping/v4/manifest');
-                                assert.strictEqual(err.status, undefined);
-                                assert.strictEqual(response, undefined);
-                                resolve();
-                            } catch (e) {
-                                reject(e);
-                            }
-                        });
-                    } catch (e) {
-                        reject(e);
-                    }
-                });
+            await assert.rejects(dhlEcommerceSolutions.createManifest({ manifests: [], pickup: '5351244' }), err => {
+                assert.strictEqual(err.message, '500 Internal Server Error');
+                assert.strictEqual(err.cause.status, 500);
+                return true;
             });
         });
 
-        t.test('should return an error for non 200 status code', { timeout: 4000 }, () => {
-            return new Promise((resolve, reject) => {
-                let dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                    client_id: process.env.CLIENT_ID,
-                    client_secret: process.env.CLIENT_SECRET
-                });
-
-                dhlEcommerceSolutions.getAccessToken((err, accessToken) => {
-                    try {
-                        assert.ifError(err);
-
-                        // Update cache
-                        cache.put('https://httpbun.com/status/500#/auth/v4/accesstoken?client_id=undefined', accessToken, accessToken.expires_in * 1000 / 2);
-
-                        dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                            environment_url: 'https://httpbun.com/status/500#'
-                        });
-
-                        dhlEcommerceSolutions.createManifest({ manifests: [], pickup: '5351244' }, (err, response) => {
-                            try {
-                                assert(err);
-                                assert.strictEqual(err.message, '500 Internal Server Error');
-                                assert.strictEqual(err.cause.status, 500);
-                                assert.strictEqual(response, undefined);
-                                resolve();
-                            } catch (e) {
-                                reject(e);
-                            }
-                        });
-                    } catch (e) {
-                        reject(e);
-                    }
-                });
-            });
-        });
-
-        t.test('should return a response', { timeout: 3000 }, () => {
-            return new Promise((resolve, reject) => {
-                const dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                    client_id: process.env.CLIENT_ID,
-                    client_secret: process.env.CLIENT_SECRET
-                });
-
-                dhlEcommerceSolutions.createManifest({ manifests: [], pickup: '5351244' }, (err, response) => {
-                    try {
-                        assert.ifError(err);
-
-                        assert.ok(response.timestamp);
-                        assert.notStrictEqual(NaN, Date.parse(response.timestamp));
-                        assert.ok(response.requestId);
-                        assert.ok(response.link);
-                        resolve();
-                    } catch (e) {
-                        reject(e);
-                    }
-                });
-            });
-        });
-
-        t.test('should reject for invalid environment_url when no callback is provided', { timeout: 1000 }, async () => {
+        t.test('should reject for invalid environment_url', { timeout: 1000 }, async () => {
             const dhlEcommerceSolutions = new DhlEcommerceSolutions({
                 environment_url: 'invalid'
             });
 
-            await assert.rejects(dhlEcommerceSolutions.createManifest({ manifests: [], pickup: '5351244' }), {
-                message: 'Failed to parse URL from invalid/auth/v4/accesstoken'
+            await assert.rejects(dhlEcommerceSolutions.createManifest({ manifests: [], pickup: '5351244' }), err => {
+                assert.strictEqual(err.message, 'Failed to parse URL from invalid/auth/v4/accesstoken');
+                assert.strictEqual(err.status, undefined);
+                return true;
             });
         });
 
-        t.test('should return a response when no callback is provided', { timeout: 3000 }, async () => {
+        t.test('should return a response', { timeout: 3000 }, async () => {
             const dhlEcommerceSolutions = new DhlEcommerceSolutions({
                 client_id: process.env.CLIENT_ID,
                 client_secret: process.env.CLIENT_SECRET
@@ -799,149 +616,63 @@ test('DhlEcommerceSolutions', { concurrency: true, timeout: 10000 }, (t) => {
     });
 
     t.test('downloadManifest', { concurrency: true, timeout: 4000 }, (t) => {
-        t.test('should return an error for invalid environment_url', { timeout: 1000 }, () => {
-            return new Promise((resolve, reject) => {
-                const dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                    environment_url: 'invalid'
-                });
+        t.test('should return an error for invalid environment_url after getAccessToken', { timeout: 3000 }, async () => {
+            let dhlEcommerceSolutions = new DhlEcommerceSolutions({
+                client_id: process.env.CLIENT_ID,
+                client_secret: process.env.CLIENT_SECRET
+            });
 
-                dhlEcommerceSolutions.downloadManifest('5351244', 'b56fe9d0-1111-2222-a11f-f8f8635f985a', (err, response) => {
-                    try {
-                        assert(err);
-                        assert.strictEqual(err.message, 'Failed to parse URL from invalid/auth/v4/accesstoken');
-                        assert.strictEqual(err.status, undefined);
-                        assert.strictEqual(response, undefined);
-                        resolve();
-                    } catch (e) {
-                        reject(e);
-                    }
-                });
+            const accessToken = await dhlEcommerceSolutions.getAccessToken();
+
+            // Update cache
+            cache.put('invalid/auth/v4/accesstoken?client_id=undefined', accessToken, accessToken.expires_in * 1000 / 2);
+
+            dhlEcommerceSolutions = new DhlEcommerceSolutions({
+                environment_url: 'invalid'
+            });
+
+            await assert.rejects(dhlEcommerceSolutions.downloadManifest('5351244', 'b56fe9d0-1111-2222-a11f-f8f8635f985a'), err => {
+                assert.strictEqual(err.message, 'Failed to parse URL from invalid/shipping/v4/manifest/5351244/b56fe9d0-1111-2222-a11f-f8f8635f985a');
+                assert.strictEqual(err.status, undefined);
+                return true;
             });
         });
 
-        t.test('should return an error for invalid environment_url after getAccessToken', { timeout: 3000 }, () => {
-            return new Promise((resolve, reject) => {
-                let dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                    client_id: process.env.CLIENT_ID,
-                    client_secret: process.env.CLIENT_SECRET
-                });
+        t.test('should return an error for non 200 status code', { timeout: 4000 }, async () => {
+            let dhlEcommerceSolutions = new DhlEcommerceSolutions({
+                client_id: process.env.CLIENT_ID,
+                client_secret: process.env.CLIENT_SECRET
+            });
 
-                dhlEcommerceSolutions.getAccessToken((err, accessToken) => {
-                    try {
-                        assert.ifError(err);
+            const accessToken = await dhlEcommerceSolutions.getAccessToken();
 
-                        // Update cache
-                        cache.put('invalid/auth/v4/accesstoken?client_id=undefined', accessToken, accessToken.expires_in * 1000 / 2);
+            // Update cache
+            cache.put('https://httpbun.com/status/500#/auth/v4/accesstoken?client_id=undefined', accessToken, accessToken.expires_in * 1000 / 2);
 
-                        dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                            environment_url: 'invalid'
-                        });
+            dhlEcommerceSolutions = new DhlEcommerceSolutions({
+                environment_url: 'https://httpbun.com/status/500#'
+            });
 
-                        dhlEcommerceSolutions.downloadManifest('5351244', 'b56fe9d0-1111-2222-a11f-f8f8635f985a', (err, response) => {
-                            try {
-                                assert(err);
-                                assert.strictEqual(err.message, 'Failed to parse URL from invalid/shipping/v4/manifest/5351244/b56fe9d0-1111-2222-a11f-f8f8635f985a');
-                                assert.strictEqual(err.status, undefined);
-                                assert.strictEqual(response, undefined);
-                                resolve();
-                            } catch (e) {
-                                reject(e);
-                            }
-                        });
-                    } catch (e) {
-                        reject(e);
-                    }
-                });
+            await assert.rejects(dhlEcommerceSolutions.downloadManifest('5351244', 'b56fe9d0-1111-2222-a11f-f8f8635f985a'), err => {
+                assert.strictEqual(err.message, '500 Internal Server Error');
+                assert.strictEqual(err.cause.status, 500);
+                return true;
             });
         });
 
-        t.test('should return an error for non 200 status code', { timeout: 4000 }, () => {
-            return new Promise((resolve, reject) => {
-                let dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                    client_id: process.env.CLIENT_ID,
-                    client_secret: process.env.CLIENT_SECRET
-                });
-
-                dhlEcommerceSolutions.getAccessToken((err, accessToken) => {
-                    try {
-                        assert.ifError(err);
-
-                        // Update cache
-                        cache.put('https://httpbun.com/status/500#/auth/v4/accesstoken?client_id=undefined', accessToken, accessToken.expires_in * 1000 / 2);
-
-                        dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                            environment_url: 'https://httpbun.com/status/500#'
-                        });
-
-                        dhlEcommerceSolutions.downloadManifest('5351244', 'b56fe9d0-1111-2222-a11f-f8f8635f985a', (err, response) => {
-                            try {
-                                assert(err);
-                                assert.strictEqual(err.message, '500 Internal Server Error');
-                                assert.strictEqual(err.cause.status, 500);
-                                assert.strictEqual(response, undefined);
-                                resolve();
-                            } catch (e) {
-                                reject(e);
-                            }
-                        });
-                    } catch (e) {
-                        reject(e);
-                    }
-                });
-            });
-        });
-
-        t.test('should return a response', { timeout: 3000 }, () => {
-            return new Promise((resolve, reject) => {
-                const dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                    client_id: process.env.CLIENT_ID,
-                    client_secret: process.env.CLIENT_SECRET
-                });
-
-                const pickup = '5351244';
-
-                dhlEcommerceSolutions.createManifest({ manifests: [], pickup }, (err, response) => {
-                    try {
-                        assert.ifError(err);
-                        assert.ok(response.requestId);
-
-                        const requestId = response.requestId;
-
-                        dhlEcommerceSolutions.downloadManifest(pickup, requestId, (err, response) => {
-                            try {
-                                assert.ifError(err);
-                                assert.ifError(response.errorCode);
-                                assert.ifError(response.errorDescription);
-
-                                assert.ok(response.manifestSummary);
-                                assert(Number.isInteger(response.manifestSummary.total));
-                                assert.strictEqual(pickup, response.pickup);
-                                assert.strictEqual(requestId, response.requestId);
-                                assert.strictEqual(['CREATED', 'IN_PROGRESS', 'COMPLETED'].includes(response.status), true);
-                                assert.notStrictEqual(NaN, Date.parse(response.timestamp));
-                                resolve();
-                            } catch (e) {
-                                reject(e);
-                            }
-                        });
-                    } catch (e) {
-                        reject(e);
-                    }
-                });
-            });
-        });
-
-        t.test('should reject for invalid environment_url when no callback is provided', { timeout: 1000 }, async () => {
+        t.test('should reject for invalid environment_url', { timeout: 1000 }, async () => {
             const dhlEcommerceSolutions = new DhlEcommerceSolutions({
                 environment_url: 'invalid'
             });
 
-            await assert.rejects(dhlEcommerceSolutions.downloadManifest('5351244', 'b56fe9d0-1111-2222-a11f-f8f8635f985a'), {
-                message: 'Failed to parse URL from invalid/auth/v4/accesstoken'
+            await assert.rejects(dhlEcommerceSolutions.downloadManifest('5351244', 'b56fe9d0-1111-2222-a11f-f8f8635f985a'), err => {
+                assert.strictEqual(err.message, 'Failed to parse URL from invalid/auth/v4/accesstoken');
+                assert.strictEqual(err.status, undefined);
+                return true;
             });
         });
 
-        t.test('should return a response when no callback is provided', { timeout: 3000 }, async () => {
+        t.test('should return a response', { timeout: 3000 }, async () => {
             const dhlEcommerceSolutions = new DhlEcommerceSolutions({
                 client_id: process.env.CLIENT_ID,
                 client_secret: process.env.CLIENT_SECRET
@@ -977,179 +708,72 @@ test('DhlEcommerceSolutions', { concurrency: true, timeout: 10000 }, (t) => {
     });
 
     t.test('findProducts', { concurrency: true, timeout: 10000 }, (t) => {
-        t.test('should return an error for invalid environment_url', { timeout: 1000 }, () => {
-            return new Promise((resolve, reject) => {
-                const dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                    environment_url: 'invalid'
-                });
+        t.test('should return an error for invalid environment_url after getAccessToken', { timeout: 3000 }, async () => {
+            let dhlEcommerceSolutions = new DhlEcommerceSolutions({
+                client_id: process.env.CLIENT_ID,
+                client_secret: process.env.CLIENT_SECRET
+            });
 
-                dhlEcommerceSolutions.findProducts({}, (err, response) => {
-                    try {
-                        assert(err);
-                        assert.strictEqual(err.message, 'Failed to parse URL from invalid/auth/v4/accesstoken');
-                        assert.strictEqual(err.status, undefined);
-                        assert.strictEqual(response, undefined);
-                        resolve();
-                    } catch (e) {
-                        reject(e);
-                    }
-                });
+            const accessToken = await dhlEcommerceSolutions.getAccessToken();
+
+            dhlEcommerceSolutions = new DhlEcommerceSolutions({
+                environment_url: 'invalid'
+            });
+
+            // Update cache
+            cache.put('invalid/auth/v4/accesstoken?client_id=undefined', accessToken, accessToken.expires_in * 1000 / 2);
+
+            await assert.rejects(dhlEcommerceSolutions.findProducts({}), err => {
+                assert.strictEqual(err.message, 'Failed to parse URL from invalid/shipping/v4/products');
+                assert.strictEqual(err.status, undefined);
+                return true;
             });
         });
 
-        t.test('should return an error for invalid environment_url after getAccessToken', { timeout: 3000 }, () => {
-            return new Promise((resolve, reject) => {
-                let dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                    client_id: process.env.CLIENT_ID,
-                    client_secret: process.env.CLIENT_SECRET
-                });
+        t.test('should return an error for non 200 status code', { timeout: 8000 }, async () => {
+            let dhlEcommerceSolutions = new DhlEcommerceSolutions({
+                client_id: process.env.CLIENT_ID,
+                client_secret: process.env.CLIENT_SECRET
+            });
 
-                dhlEcommerceSolutions.getAccessToken((err, accessToken) => {
-                    try {
-                        assert.ifError(err);
+            await dhlEcommerceSolutions.getAccessToken();
 
-                        dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                            environment_url: 'invalid'
-                        });
+            dhlEcommerceSolutions = new DhlEcommerceSolutions({
+                environment_url: 'https://httpbun.com/status/500#'
+            });
 
-                        // Update cache
-                        cache.put('invalid/auth/v4/accesstoken?client_id=undefined', accessToken, accessToken.expires_in * 1000 / 2);
-
-                        dhlEcommerceSolutions.findProducts({}, (err, response) => {
-                            try {
-                                assert(err);
-                                assert.strictEqual(err.message, 'Failed to parse URL from invalid/shipping/v4/products');
-                                assert.strictEqual(err.status, undefined);
-                                assert.strictEqual(response, undefined);
-                                resolve();
-                            } catch (e) {
-                                reject(e);
-                            }
-                        });
-                    } catch (e) {
-                        reject(e);
-                    }
-                });
+            await assert.rejects(dhlEcommerceSolutions.findProducts({}), err => {
+                assert.strictEqual(err.message, '500 Internal Server Error');
+                assert.strictEqual(err.cause.status, 500);
+                return true;
             });
         });
 
-        t.test('should return an error for non 200 status code', { timeout: 8000 }, () => {
-            return new Promise((resolve, reject) => {
-                let dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                    client_id: process.env.CLIENT_ID,
-                    client_secret: process.env.CLIENT_SECRET
-                });
+        t.test('should return an error when no body is specified', { timeout: 3000 }, async () => {
+            const dhlEcommerceSolutions = new DhlEcommerceSolutions({
+                client_id: process.env.CLIENT_ID,
+                client_secret: process.env.CLIENT_SECRET
+            });
 
-                dhlEcommerceSolutions.getAccessToken((err) => {
-                    try {
-                        assert.ifError(err);
-
-                        dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                            environment_url: 'https://httpbun.com/status/500#'
-                        });
-
-                        dhlEcommerceSolutions.findProducts({}, (err, response) => {
-                            try {
-                                assert(err);
-                                assert.strictEqual(err.message, '500 Internal Server Error');
-                                assert.strictEqual(err.cause.status, 500);
-                                assert.strictEqual(response, undefined);
-                                resolve();
-                            } catch (e) {
-                                reject(e);
-                            }
-                        });
-                    } catch (e) {
-                        reject(e);
-                    }
-                });
+            await assert.rejects(dhlEcommerceSolutions.findProducts({}), err => {
+                assert.strictEqual(err.cause.status, 400);
+                return true;
             });
         });
 
-        t.test('should return an error when no body is specified', { timeout: 3000 }, () => {
-            return new Promise((resolve, reject) => {
-                const dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                    client_id: process.env.CLIENT_ID,
-                    client_secret: process.env.CLIENT_SECRET
-                });
-
-                dhlEcommerceSolutions.findProducts({}, (err, response) => {
-                    try {
-                        assert(err);
-                        assert.strictEqual(err.cause.status, 400);
-                        assert.strictEqual(response, undefined);
-                        resolve();
-                    } catch (e) {
-                        reject(e);
-                    }
-                });
-            });
-        });
-
-        t.test('should return a valid response', { timeout: 10000 }, () => {
-            return new Promise((resolve, reject) => {
-                const dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                    client_id: process.env.CLIENT_ID,
-                    client_secret: process.env.CLIENT_SECRET
-                });
-
-                const _request = {
-                    consigneeAddress: {
-                        address1: '114 Whitney Ave',
-                        city: 'New Haven',
-                        country: 'US',
-                        name: 'John Doe',
-                        postalCode: '06510',
-                        state: 'CT'
-                    },
-                    distributionCenter: 'USDFW1',
-                    packageDetail: {
-                        packageDescription: 'ORDER NO 20483739DFDR',
-                        packageId: 'GM60511234500000001',
-                        weight: {
-                            unitOfMeasure: 'LB',
-                            value: 3
-                        }
-                    },
-                    pickup: '5351244',
-                    rate: {
-                        calculate: true,
-                        currency: 'USD'
-                    },
-                    returnAddress: {
-                        address1: '1950 Parker Road',
-                        address2: 'Receiving Door 32',
-                        city: 'Carrollton',
-                        companyName: 'Mercatalyst',
-                        country: 'US',
-                        postalCode: '75010',
-                        state: 'TX'
-                    }
-                };
-
-                dhlEcommerceSolutions.findProducts(_request, (err, response) => {
-                    try {
-                        assert.ifError(err);
-                        assert(Array.isArray(response.products));
-                        resolve();
-                    } catch (e) {
-                        reject(e);
-                    }
-                });
-            });
-        });
-
-        t.test('should reject for invalid environment_url when no callback is provided', { timeout: 1000 }, async () => {
+        t.test('should reject for invalid environment_url', { timeout: 1000 }, async () => {
             const dhlEcommerceSolutions = new DhlEcommerceSolutions({
                 environment_url: 'invalid'
             });
 
-            await assert.rejects(dhlEcommerceSolutions.findProducts({}), {
-                message: 'Failed to parse URL from invalid/auth/v4/accesstoken'
+            await assert.rejects(dhlEcommerceSolutions.findProducts({}), err => {
+                assert.strictEqual(err.message, 'Failed to parse URL from invalid/auth/v4/accesstoken');
+                assert.strictEqual(err.status, undefined);
+                return true;
             });
         });
 
-        t.test('should return a valid response when no callback is provided', { timeout: 10000 }, async () => {
+        t.test('should return a valid response', { timeout: 10000 }, async () => {
             const dhlEcommerceSolutions = new DhlEcommerceSolutions({
                 client_id: process.env.CLIENT_ID,
                 client_secret: process.env.CLIENT_SECRET
@@ -1205,110 +829,46 @@ test('DhlEcommerceSolutions', { concurrency: true, timeout: 10000 }, (t) => {
     });
 
     t.test('getAccessToken', { concurrency: true, timeout: 3000 }, (t) => {
-        t.test('should return an error for invalid environment_url', { timeout: 1000 }, () => {
-            return new Promise((resolve, reject) => {
-                const dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                    environment_url: 'invalid'
-                });
+        t.test('should return an error for non 200 status code', { timeout: 3000 }, async () => {
+            const dhlEcommerceSolutions = new DhlEcommerceSolutions({
+                client_id: process.env.CLIENT_ID,
+                client_secret: process.env.CLIENT_SECRET,
+                environment_url: 'https://httpbun.com/status/500#'
+            });
 
-                dhlEcommerceSolutions.getAccessToken((err, accessToken) => {
-                    try {
-                        assert(err);
-                        assert.strictEqual(err.message, 'Failed to parse URL from invalid/auth/v4/accesstoken');
-                        assert.strictEqual(err.status, undefined);
-                        assert.strictEqual(accessToken, undefined);
-                        resolve();
-                    } catch (e) {
-                        reject(e);
-                    }
-                });
+            await assert.rejects(dhlEcommerceSolutions.getAccessToken(), err => {
+                assert.strictEqual(err.message, '500 Internal Server Error');
+                assert.strictEqual(err.cause.status, 500);
+                return true;
             });
         });
 
-        t.test('should return an error for non 200 status code', { timeout: 3000 }, () => {
-            return new Promise((resolve, reject) => {
-                const dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                    client_id: process.env.CLIENT_ID,
-                    client_secret: process.env.CLIENT_SECRET,
-                    environment_url: 'https://httpbun.com/status/500#'
-                });
-
-                dhlEcommerceSolutions.getAccessToken((err, accessToken) => {
-                    try {
-                        assert(err);
-                        assert.strictEqual(err.message, '500 Internal Server Error');
-                        assert.strictEqual(err.cause.status, 500);
-                        assert.strictEqual(accessToken, undefined);
-                        resolve();
-                    } catch (e) {
-                        reject(e);
-                    }
-                });
+        t.test('should return the same access token on subsequent calls', { timeout: 3000 }, async () => {
+            const dhlEcommerceSolutions = new DhlEcommerceSolutions({
+                client_id: process.env.CLIENT_ID,
+                client_secret: process.env.CLIENT_SECRET
             });
+
+            const accessToken1 = await dhlEcommerceSolutions.getAccessToken();
+
+            const accessToken2 = await dhlEcommerceSolutions.getAccessToken();
+
+            assert.deepStrictEqual(accessToken2, accessToken1);
         });
 
-        t.test('should return a valid access token', { timeout: 3000 }, () => {
-            return new Promise((resolve, reject) => {
-                const dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                    client_id: process.env.CLIENT_ID,
-                    client_secret: process.env.CLIENT_SECRET
-                });
-
-                dhlEcommerceSolutions.getAccessToken((err, accessToken) => {
-                    try {
-                        assert.ifError(err);
-
-                        assert(accessToken);
-                        assert(accessToken.access_token);
-                        assert(accessToken.client_id);
-                        assert(accessToken.expires_in);
-                        assert.strictEqual(accessToken.token_type, 'Bearer');
-                        resolve();
-                    } catch (e) {
-                        reject(e);
-                    }
-                });
-            });
-        });
-
-        t.test('should return the same access token on subsequent calls', { timeout: 3000 }, () => {
-            return new Promise((resolve, reject) => {
-                const dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                    client_id: process.env.CLIENT_ID,
-                    client_secret: process.env.CLIENT_SECRET
-                });
-
-                dhlEcommerceSolutions.getAccessToken((err, accessToken1) => {
-                    try {
-                        assert.ifError(err);
-
-                        dhlEcommerceSolutions.getAccessToken((err, accessToken2) => {
-                            try {
-                                assert.ifError(err);
-                                assert.deepStrictEqual(accessToken2, accessToken1);
-                                resolve();
-                            } catch (e) {
-                                reject(e);
-                            }
-                        });
-                    } catch (e) {
-                        reject(e);
-                    }
-                });
-            });
-        });
-
-        t.test('should reject for invalid environment_url when no callback is provided', { timeout: 1000 }, async () => {
+        t.test('should reject for invalid environment_url', { timeout: 1000 }, async () => {
             const dhlEcommerceSolutions = new DhlEcommerceSolutions({
                 environment_url: 'invalid'
             });
 
-            await assert.rejects(dhlEcommerceSolutions.getAccessToken(), {
-                message: 'Failed to parse URL from invalid/auth/v4/accesstoken'
+            await assert.rejects(dhlEcommerceSolutions.getAccessToken(), err => {
+                assert.strictEqual(err.message, 'Failed to parse URL from invalid/auth/v4/accesstoken');
+                assert.strictEqual(err.status, undefined);
+                return true;
             });
         });
 
-        t.test('should return a valid access token when no callback is provided', { timeout: 3000 }, async () => {
+        t.test('should return a valid access token', { timeout: 3000 }, async () => {
             const dhlEcommerceSolutions = new DhlEcommerceSolutions({
                 client_id: process.env.CLIENT_ID,
                 client_secret: process.env.CLIENT_SECRET
@@ -1331,128 +891,63 @@ test('DhlEcommerceSolutions', { concurrency: true, timeout: 10000 }, (t) => {
     });
 
     t.test('getTrackingByPackageId', { concurrency: true, timeout: 10000 }, (t) => {
-        t.test('should return an error for invalid environment_url', { timeout: 1000 }, () => {
-            return new Promise((resolve, reject) => {
-                const dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                    environment_url: 'invalid'
-                });
+        t.test('should return an error for invalid environment_url after getAccessToken', { timeout: 3000 }, async () => {
+            let dhlEcommerceSolutions = new DhlEcommerceSolutions({
+                client_id: process.env.CLIENT_ID,
+                client_secret: process.env.CLIENT_SECRET
+            });
 
-                dhlEcommerceSolutions.getTrackingByPackageId('V4-TEST-1586965592482', (err, response) => {
-                    try {
-                        assert(err);
-                        assert.strictEqual(err.message, 'Failed to parse URL from invalid/auth/v4/accesstoken');
-                        assert.strictEqual(err.status, undefined);
-                        assert.strictEqual(response, undefined);
-                        resolve();
-                    } catch (e) {
-                        reject(e);
-                    }
-                });
+            const accessToken = await dhlEcommerceSolutions.getAccessToken();
+
+            dhlEcommerceSolutions = new DhlEcommerceSolutions({
+                environment_url: 'invalid'
+            });
+
+            // Update cache
+            cache.put('invalid/auth/v4/accesstoken?client_id=undefined', accessToken, accessToken.expires_in * 1000 / 2);
+
+            await assert.rejects(dhlEcommerceSolutions.getTrackingByPackageId('V4-TEST-1586965592482'), err => {
+                assert.strictEqual(err.message, 'Failed to parse URL from invalid/tracking/v4/package?packageId=V4-TEST-1586965592482');
+                assert.strictEqual(err.status, undefined);
+                return true;
             });
         });
 
-        t.test('should return an error for invalid environment_url after getAccessToken', { timeout: 3000 }, () => {
-            return new Promise((resolve, reject) => {
-                let dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                    client_id: process.env.CLIENT_ID,
-                    client_secret: process.env.CLIENT_SECRET
-                });
+        t.test('should return an error for non 200 status code', { timeout: 4000 }, async () => {
+            let dhlEcommerceSolutions = new DhlEcommerceSolutions({
+                client_id: process.env.CLIENT_ID,
+                client_secret: process.env.CLIENT_SECRET
+            });
 
-                dhlEcommerceSolutions.getAccessToken((err, accessToken) => {
-                    try {
-                        assert.ifError(err);
+            const accessToken = await dhlEcommerceSolutions.getAccessToken();
 
-                        dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                            environment_url: 'invalid'
-                        });
+            // Update cache
+            cache.put('https://httpbun.com/status/500#/auth/v4/accesstoken?client_id=undefined', accessToken, accessToken.expires_in * 1000 / 2);
 
-                        // Update cache
-                        cache.put('invalid/auth/v4/accesstoken?client_id=undefined', accessToken, accessToken.expires_in * 1000 / 2);
+            dhlEcommerceSolutions = new DhlEcommerceSolutions({
+                environment_url: 'https://httpbun.com/status/500#'
+            });
 
-                        dhlEcommerceSolutions.getTrackingByPackageId('V4-TEST-1586965592482', (err, response) => {
-                            try {
-                                assert(err);
-                                assert.strictEqual(err.message, 'Failed to parse URL from invalid/tracking/v4/package?packageId=V4-TEST-1586965592482');
-                                assert.strictEqual(err.status, undefined);
-                                assert.strictEqual(response, undefined);
-                                resolve();
-                            } catch (e) {
-                                reject(e);
-                            }
-                        });
-                    } catch (e) {
-                        reject(e);
-                    }
-                });
+            await assert.rejects(dhlEcommerceSolutions.getTrackingByPackageId('V4-TEST-1586965592482'), err => {
+                assert.strictEqual(err.message, '500 Internal Server Error');
+                assert.strictEqual(err.cause.status, 500);
+                return true;
             });
         });
 
-        t.test('should return an error for non 200 status code', { timeout: 4000 }, () => {
-            return new Promise((resolve, reject) => {
-                let dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                    client_id: process.env.CLIENT_ID,
-                    client_secret: process.env.CLIENT_SECRET
-                });
-
-                dhlEcommerceSolutions.getAccessToken((err, accessToken) => {
-                    try {
-                        assert.ifError(err);
-
-                        // Update cache
-                        cache.put('https://httpbun.com/status/500#/auth/v4/accesstoken?client_id=undefined', accessToken, accessToken.expires_in * 1000 / 2);
-
-                        dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                            environment_url: 'https://httpbun.com/status/500#'
-                        });
-
-                        dhlEcommerceSolutions.getTrackingByPackageId('V4-TEST-1586965592482', (err, response) => {
-                            try {
-                                assert(err);
-                                assert.strictEqual(err.message, '500 Internal Server Error');
-                                assert.strictEqual(err.cause.status, 500);
-                                assert.strictEqual(response, undefined);
-                                resolve();
-                            } catch (e) {
-                                reject(e);
-                            }
-                        });
-                    } catch (e) {
-                        reject(e);
-                    }
-                });
-            });
-        });
-
-        t.test('should return a response', { timeout: 10000 }, () => {
-            return new Promise((resolve, reject) => {
-                const dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                    client_id: process.env.CLIENT_ID,
-                    client_secret: process.env.CLIENT_SECRET
-                });
-
-                dhlEcommerceSolutions.getTrackingByPackageId('V4-TEST-1586965592482', (err, response) => {
-                    try {
-                        assert.ifError(err);
-                        assert.strictEqual(response.packages[0].package.packageId, 'V4-TEST-1586965592482');
-                        resolve();
-                    } catch (e) {
-                        reject(e);
-                    }
-                });
-            });
-        });
-
-        t.test('should reject for invalid environment_url when no callback is provided', { timeout: 1000 }, async () => {
+        t.test('should reject for invalid environment_url', { timeout: 1000 }, async () => {
             const dhlEcommerceSolutions = new DhlEcommerceSolutions({
                 environment_url: 'invalid'
             });
 
-            await assert.rejects(dhlEcommerceSolutions.getTrackingByPackageId('V4-TEST-1586965592482'), {
-                message: 'Failed to parse URL from invalid/auth/v4/accesstoken'
+            await assert.rejects(dhlEcommerceSolutions.getTrackingByPackageId('V4-TEST-1586965592482'), err => {
+                assert.strictEqual(err.message, 'Failed to parse URL from invalid/auth/v4/accesstoken');
+                assert.strictEqual(err.status, undefined);
+                return true;
             });
         });
 
-        t.test('should return a response when no callback is provided', { timeout: 10000 }, async () => {
+        t.test('should return a response', { timeout: 10000 }, async () => {
             const dhlEcommerceSolutions = new DhlEcommerceSolutions({
                 client_id: process.env.CLIENT_ID,
                 client_secret: process.env.CLIENT_SECRET
@@ -1474,128 +969,63 @@ test('DhlEcommerceSolutions', { concurrency: true, timeout: 10000 }, (t) => {
     });
 
     t.test('getTrackingByTrackingId', { concurrency: true, timeout: 10000 }, (t) => {
-        t.test('should return an error for invalid environment_url', { timeout: 1000 }, () => {
-            return new Promise((resolve, reject) => {
-                const dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                    environment_url: 'invalid'
-                });
+        t.test('should return an error for invalid environment_url after getAccessToken', { timeout: 3000 }, async () => {
+            let dhlEcommerceSolutions = new DhlEcommerceSolutions({
+                client_id: process.env.CLIENT_ID,
+                client_secret: process.env.CLIENT_SECRET
+            });
 
-                dhlEcommerceSolutions.getTrackingByTrackingId('9374869903500011991299', (err, response) => {
-                    try {
-                        assert(err);
-                        assert.strictEqual(err.message, 'Failed to parse URL from invalid/auth/v4/accesstoken');
-                        assert.strictEqual(err.status, undefined);
-                        assert.strictEqual(response, undefined);
-                        resolve();
-                    } catch (e) {
-                        reject(e);
-                    }
-                });
+            const accessToken = await dhlEcommerceSolutions.getAccessToken();
+
+            dhlEcommerceSolutions = new DhlEcommerceSolutions({
+                environment_url: 'invalid'
+            });
+
+            // Update cache
+            cache.put('invalid/auth/v4/accesstoken?client_id=undefined', accessToken, accessToken.expires_in * 1000 / 2);
+
+            await assert.rejects(dhlEcommerceSolutions.getTrackingByTrackingId('9374869903500011991299'), err => {
+                assert.strictEqual(err.message, 'Failed to parse URL from invalid/tracking/v4/package?trackingId=9374869903500011991299');
+                assert.strictEqual(err.status, undefined);
+                return true;
             });
         });
 
-        t.test('should return an error for invalid environment_url after getAccessToken', { timeout: 3000 }, () => {
-            return new Promise((resolve, reject) => {
-                let dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                    client_id: process.env.CLIENT_ID,
-                    client_secret: process.env.CLIENT_SECRET
-                });
+        t.test('should return an error for non 200 status code', { timeout: 4000 }, async () => {
+            let dhlEcommerceSolutions = new DhlEcommerceSolutions({
+                client_id: process.env.CLIENT_ID,
+                client_secret: process.env.CLIENT_SECRET
+            });
 
-                dhlEcommerceSolutions.getAccessToken((err, accessToken) => {
-                    try {
-                        assert.ifError(err);
+            const accessToken = await dhlEcommerceSolutions.getAccessToken();
 
-                        dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                            environment_url: 'invalid'
-                        });
+            // Update cache
+            cache.put('https://httpbun.com/status/500#/auth/v4/accesstoken?client_id=undefined', accessToken, accessToken.expires_in * 1000 / 2);
 
-                        // Update cache
-                        cache.put('invalid/auth/v4/accesstoken?client_id=undefined', accessToken, accessToken.expires_in * 1000 / 2);
+            dhlEcommerceSolutions = new DhlEcommerceSolutions({
+                environment_url: 'https://httpbun.com/status/500#'
+            });
 
-                        dhlEcommerceSolutions.getTrackingByTrackingId('9374869903500011991299', (err, response) => {
-                            try {
-                                assert(err);
-                                assert.strictEqual(err.message, 'Failed to parse URL from invalid/tracking/v4/package?trackingId=9374869903500011991299');
-                                assert.strictEqual(err.status, undefined);
-                                assert.strictEqual(response, undefined);
-                                resolve();
-                            } catch (e) {
-                                reject(e);
-                            }
-                        });
-                    } catch (e) {
-                        reject(e);
-                    }
-                });
+            await assert.rejects(dhlEcommerceSolutions.getTrackingByTrackingId('9374869903500011991299'), err => {
+                assert.strictEqual(err.message, '500 Internal Server Error');
+                assert.strictEqual(err.cause.status, 500);
+                return true;
             });
         });
 
-        t.test('should return an error for non 200 status code', { timeout: 4000 }, () => {
-            return new Promise((resolve, reject) => {
-                let dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                    client_id: process.env.CLIENT_ID,
-                    client_secret: process.env.CLIENT_SECRET
-                });
-
-                dhlEcommerceSolutions.getAccessToken((err, accessToken) => {
-                    try {
-                        assert.ifError(err);
-
-                        // Update cache
-                        cache.put('https://httpbun.com/status/500#/auth/v4/accesstoken?client_id=undefined', accessToken, accessToken.expires_in * 1000 / 2);
-
-                        dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                            environment_url: 'https://httpbun.com/status/500#'
-                        });
-
-                        dhlEcommerceSolutions.getTrackingByTrackingId('9374869903500011991299', (err, response) => {
-                            try {
-                                assert(err);
-                                assert.strictEqual(err.message, '500 Internal Server Error');
-                                assert.strictEqual(err.cause.status, 500);
-                                assert.strictEqual(response, undefined);
-                                resolve();
-                            } catch (e) {
-                                reject(e);
-                            }
-                        });
-                    } catch (e) {
-                        reject(e);
-                    }
-                });
-            });
-        });
-
-        t.test('should return a response', { timeout: 10000 }, () => {
-            return new Promise((resolve, reject) => {
-                const dhlEcommerceSolutions = new DhlEcommerceSolutions({
-                    client_id: process.env.CLIENT_ID,
-                    client_secret: process.env.CLIENT_SECRET
-                });
-
-                dhlEcommerceSolutions.getTrackingByTrackingId('9374869903500011991299', (err, response) => {
-                    try {
-                        assert.ifError(err);
-                        assert.strictEqual(response.packages.length, 0);
-                        resolve();
-                    } catch (e) {
-                        reject(e);
-                    }
-                });
-            });
-        });
-
-        t.test('should reject for invalid environment_url when no callback is provided', { timeout: 1000 }, async () => {
+        t.test('should reject for invalid environment_url', { timeout: 1000 }, async () => {
             const dhlEcommerceSolutions = new DhlEcommerceSolutions({
                 environment_url: 'invalid'
             });
 
-            await assert.rejects(dhlEcommerceSolutions.getTrackingByTrackingId('9374869903500011991299'), {
-                message: 'Failed to parse URL from invalid/auth/v4/accesstoken'
+            await assert.rejects(dhlEcommerceSolutions.getTrackingByTrackingId('9374869903500011991299'), err => {
+                assert.strictEqual(err.message, 'Failed to parse URL from invalid/auth/v4/accesstoken');
+                assert.strictEqual(err.status, undefined);
+                return true;
             });
         });
 
-        t.test('should return a response when no callback is provided', { timeout: 10000 }, async () => {
+        t.test('should return a response', { timeout: 10000 }, async () => {
             const dhlEcommerceSolutions = new DhlEcommerceSolutions({
                 client_id: process.env.CLIENT_ID,
                 client_secret: process.env.CLIENT_SECRET


### PR DESCRIPTION
## Why

Every caller now awaits. bloodhound awaits at `carriers/dhlEcommerceSolutions.js:111` (their #181), and fulfillment-service awaits at all five DHL call sites after #920 — `routes/labels.js:129,138`, `routes/rates.js:583`, `handlers/dhl.js:24,36`. With no users left, the callback branch is dead weight.

stores-com/runbook still passes callbacks in `util/dhl/test.js:14,64` and `util/dhl/webhooks.js:36`. Those are utility scripts, not load-bearing, and migrate later — confirmed before opening this.

## What

Each method becomes a plain `async function`; the `executor` wrapper, the `if (callback)` branch, and the `typeof _options === 'function'` guard all go with it. `index.js` drops from 331 lines to 233.

Because the callback argument is gone, nothing has to disambiguate an options object from a function anymore — options stay in the same position they already occupied.

## Tests

**Converted, not deleted.** Only 14 tests had await twins from #11 — one success and one rejection per method. The other 17 callback tests are the only coverage of their behaviour: non-200 handling, a missing request body, PNG label format, and access token reuse. Deleting those to remove callbacks would have quietly dropped real coverage.

- 17 callback tests converted to `await` / `assert.rejects`, keeping every assertion that wasn't callback-specific.
- 14 deleted as exact duplicates of a surviving twin. The one non-obvious case — `downloadManifest` "should return a response", which chains `createManifest` first — was compared assertion by assertion before deleting.
- The 7 surviving `invalid environment_url` twins gained the `assert.strictEqual(err.status, undefined)` assertion their callback siblings carried, so that check survives the deletion.
- Dropped assertions are callback-only: `assert.ifError(err)`, `assert(err)`, and `assert.strictEqual(response, undefined)`.

Suite goes from 55 leaf tests to 41, 1617 lines to 1047.

Locally, without DHL credentials, every live-sandbox test fails on both branches. Comparing failing test names between `665c16b` and this branch: **nothing fails here that doesn't fail on main**, and the only baseline-only failures are the three twins this PR renames. CI has the secrets, so treat its run as the real result.

## Docs

README loses the callback examples and the `[callback]` parameters; CHANGELOG gets a `1.0.0` entry with the breaking change and the migration line; CLAUDE.md's method description is corrected. Version bumped to 1.0.0 as requested.

Consumers must move to `^1.0.0` deliberately — this is breaking for outside users of the package too, not just this org.
